### PR TITLE
Fix for Ascendant nodes double-granting passive points.

### DIFF
--- a/Classes/PassiveTree.lua
+++ b/Classes/PassiveTree.lua
@@ -265,7 +265,9 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 			node.oidx = node.orbitIndex
 			node.dn = node.name
 			node.sd = node.stats
-			node.passivePointsGranted = node.grantedPassivePoints or 0
+			-- The only effect of passivePointsGranted is to add "Grants N Passive Skill Point(s)" line to the passive.
+			-- However, the new 3.10 tree already contains that line, so there's no need to duplicate it.
+			node.passivePointsGranted = 0
 		end
 
 		nodeMap[node.id] = node


### PR DESCRIPTION
The only effect of passivePointsGranted is to add "Grants N Passive Skill Point(s)" line to the passive.
However, the new 3.10 tree already contains that line, so there's no need to duplicate it.