### PR TITLE
Fix for new "ModFlagOr" tag not functioning properly

### DIFF
--- a/Classes/ModStore.lua
+++ b/Classes/ModStore.lua
@@ -429,10 +429,10 @@ function ModStoreClass:EvalMod(mod, cfg)
 				return
 			end
 		elseif tag.type == "ModFlagOr" then
-			if not cfg or not cfg.modFlags then
+			if not cfg or not cfg.flags then
 				return
 			end
-			if band(cfg.modFlags, tag.modFlags) == 0 then
+			if band(cfg.flags, tag.modFlags) == 0 then
 				return
 			end
 		elseif tag.type == "KeywordFlagAnd" then


### PR DESCRIPTION
The "ModFlagOr" tag was checking against cfg.modFlags which does not exist
 - Changed it to cfg.flags which is the proper name.

Mod is active with Axe or Sword equipped:
![Axe](https://user-images.githubusercontent.com/10701249/76461747-b40d3080-639d-11ea-973a-313e97978626.png)
![Sword](https://user-images.githubusercontent.com/10701249/76461749-b4a5c700-639d-11ea-9e44-f497300ba112.png)

Mod is inactive with Mace equipped:
![Mace](https://user-images.githubusercontent.com/10701249/76461748-b4a5c700-639d-11ea-9cc7-74137759521d.png)